### PR TITLE
Disable buttons when hidden

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Run `npm run ios` to open a simulator (requires XCode)
 Make `Begin` button styling better\
 Improve button spacing on timer screen\
 Prevent hiding the timer when paused\
-Disable buttons when timer is hidden\
 Improve dark theme color scheme\
 Add logo to home screen
 

--- a/src/components/Timer.tsx
+++ b/src/components/Timer.tsx
@@ -9,9 +9,10 @@ import { formatTime } from "../utilities/helpers";
 interface ITimerProps {
   duration: number;
   navigation: any;
+  screenHidden: boolean;
 }
 
-const Timer = ({ duration, navigation }: ITimerProps) => {
+const Timer = ({ duration, navigation, screenHidden }: ITimerProps) => {
   const [count, setCount] = useState<number>(duration + 1);
   const [paused, setPaused] = useState<boolean>(false);
   const [starting, setStarting] = useState<boolean>(true);
@@ -66,17 +67,17 @@ const Timer = ({ duration, navigation }: ITimerProps) => {
     <View style={styles.container}>
       <Text style={styles.timerText}>{formatTime(count)}</Text>
       <View style={styles.horizontalContainer}>
-        <TouchableOpacity onPress={discardPressed}>
+        <TouchableOpacity onPress={discardPressed} disabled={screenHidden}>
           {paused ? <Feather name="trash" color="white" size={36} /> : null}
         </TouchableOpacity>
-        <TouchableOpacity onPress={onPlayPausePressed}>
+        <TouchableOpacity  onPress={onPlayPausePressed} disabled={screenHidden}>
           {paused ? (
             <Feather name="play" color="white" size={36} />
           ) : (
             <Feather name="pause" color="white" size={36} />
           )}
         </TouchableOpacity>
-        <TouchableOpacity onPress={finishEarlyPressed}>
+        <TouchableOpacity onPress={finishEarlyPressed} disabled={screenHidden}>
           {paused ? <Feather name="check" color="white" size={36} /> : null}
         </TouchableOpacity>
       </View>

--- a/src/screens/TimerScreen.tsx
+++ b/src/screens/TimerScreen.tsx
@@ -11,12 +11,12 @@ import { useKeepAwake } from "expo-keep-awake";
 const TimerScreen = ({ navigation }: any) => {
   const duration = navigation.getParam("duration", 10) * 60;
   const [opacity] = useState(new Animated.Value(1));
-  const [hidden, setHidden] = useState(false);
+  const [screenHidden, setScreenHidden] = useState(false);
 
   useKeepAwake();
 
   const screenPressed = () => {
-    if (hidden) {
+    if (screenHidden) {
       Animated.timing(opacity, {
         toValue: 1,
         easing: Easing.cubic,
@@ -29,7 +29,7 @@ const TimerScreen = ({ navigation }: any) => {
         duration: 800,
       }).start();
     }
-    setHidden(!hidden);
+    setScreenHidden(!screenHidden);
     return true;
   };
   return (
@@ -38,7 +38,7 @@ const TimerScreen = ({ navigation }: any) => {
       opacity={opacity}
       onStartShouldSetResponder={screenPressed}>
       <FadeIn />
-      <Timer duration={duration} navigation={navigation} />
+      <Timer duration={duration} navigation={navigation} screenHidden={screenHidden}/>
     </Animated.View>
   );
 };


### PR DESCRIPTION
When the screen is hidden on the timer screen, disable the buttons (e.g. pause, delete) so that users don't accidentally click on them.

Tested this works on an emulated phone in android studio.